### PR TITLE
bugfix

### DIFF
--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -138,7 +138,7 @@ genomeObject_name=None
 if args.genomeObjectFile:
     #try:
     genomeObject = json.load(open(args.genomeObjectFile))
-    genomeObjectGenePgfams = patric_api.getPatricGenesPgfamsForGenomeObject(genomeObject)
+    genomeObjectGenePgfams = phylocode.getPatricGenesPgfamsForGenomeObject(genomeObject)
     genomeGenePgfamList.extend(genomeObjectGenePgfams)
     genomeObject_genomeId = genomeObject['id']
     genomeObject_name = genomeObject['scientific_name']


### PR DESCRIPTION
Bugfix for module name.

Still getting this error:

```
p3x-build-codon-tree --maxGenes 5 --maxAllowedDups 1 --maxGenomesMissing 2 --bootstrapReps 100 --threads 4 --outputDirectory codon_tree --raxmlExecutable raxmlHPC-PTHREADS-SSE3 --genomeObjectFile annotation-with-stats.genome --genomeIdsFile tree_ingroup.txt
Patric user = olson@patricbrc.org
/disks/patric-common/runtime/bin/raxmlHPC-PTHREADS-SSE3
/disks/patric-common/runtime/bin/muscle
/disks/patric-common/runtime/lib/python2.7/site-packages/Bio/codonalign/__init__.py:585: UserWarning: fig|1408456.3.peg.473(W 157) does not correspond to fig|1408456.3.peg.473(tga)
  % (pro.id, aa, aa_num, nucl.id, this_codon))
/disks/patric-common/runtime/lib/python2.7/site-packages/Bio/codonalign/__init__.py:585: UserWarning: fig|1408456.3.peg.228(W 82) does not correspond to fig|1408456.3.peg.228(tga)
  % (pro.id, aa, aa_num, nucl.id, this_codon))
/disks/patric-common/runtime/lib/python2.7/site-packages/Bio/codonalign/__init__.py:585: UserWarning: fig|1408456.3.peg.548(W 277) does not correspond to fig|1408456.3.peg.548(tga)
  % (pro.id, aa, aa_num, nucl.id, this_codon))
Traceback (most recent call last):
  File "/home/olson/P3/dev-binning/deployment/pybin/p3x-build-codon-tree.py", line 316, in <module>
    phylocode.outputCodonsProteinsPhylip(codonAlignments, proteinAlignments, args.outputDirectory+phyloFileBase+".phy")
  File "/home/olson/P3/dev-binning/deployment/lib/phylocode.py", line 405, in outputCodonsProteinsPhylip
    writeOneAlignmentPhylip(codonAlignments[alignmentIdList[0]], destination, taxonIdList, outputIds=True)
IndexError: list index out of range
Error creating tree
```