### PR TITLE
remove reference to pathToCodonTreeLib

### DIFF
--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -138,7 +138,7 @@ genomeObject_name=None
 if args.genomeObjectFile:
     #try:
     genomeObject = json.load(open(args.genomeObjectFile))
-    genomeObjectGenePgfams = patric_api.getPatricGenesPgfamsForGenomeObject(genomeObject)
+    genomeObjectGenePgfams = phylocode.getPatricGenesPgfamsForGenomeObject(genomeObject)
     genomeGenePgfamList.extend(genomeObjectGenePgfams)
     genomeObject_genomeId = genomeObject['id']
     genomeObject_name = genomeObject['scientific_name']

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -385,9 +385,6 @@ if not args.deferRaxml:
         nexusOut.close()
         LOG.write("nexus file written to %s\n"%nexusOutfileName)
         LOG.flush()
-        if not args.pathToFigtreeJar:
-            if os.path.exists(os.path.join(Codon_trees_lib_path, "figtree.jar")):
-                args.pathToFigtreeJar = os.path.join(Codon_trees_lib_path, "figtree.jar")
         if not (args.pathToFigtreeJar and os.path.exists(args.pathToFigtreeJar)):
             LOG.write("Could not find valid path to figtree.jar")
             args.pathToFigtreeJar = None


### PR DESCRIPTION
can specify path to figtree.jar if needed
