### PR TITLE
Changes to tolerate genome object redundant with genome in database.

### DIFF
--- a/lib/patric_api.py
+++ b/lib/patric_api.py
@@ -51,8 +51,8 @@ def getGenomeGroupIds(genomeGroupName):
         LOG.write(ret.url+"\n")
     return(ret.text.replace('"', '').split("\n"))[1:-1]
 
-def getNamesForGenomeIds(genomeIdList):
-    return getDataForGenomes(genomeIdList, ["genome_id", "genome_name"])
+def getNamesForGenomeIds(genomeIdSet):
+    return getDataForGenomes(genomeIdSet, ["genome_id", "genome_name"])
 
 def getGenomeIdsByFieldValue(queryField, queryValue):
     req = sesssion.get(Base_url+"genome/", params="in(%s,%s)"%(queryField, queryValue)) 
@@ -64,11 +64,11 @@ def getGenomeIdsByFieldValue(queryField, queryValue):
        retval.append(line)
     return retval
 
-def getDataForGenomes(genomeIdList, fieldNames):
-    query = "in(genome_id,(%s))"%",".join(genomeIdList)
+def getDataForGenomes(genomeIdSet, fieldNames):
+    query = "in(genome_id,(%s))"%",".join(genomeIdSet)
     if fieldNames:
         query += "&select(%s)"%",".join(fieldNames)
-    query += "&limit(%s)"%len(genomeIdList)
+    query += "&limit(%s)"%len(genomeIdSet)
 
     response = Session.get(Base_url+"genome/", params=query)
     if Debug:
@@ -177,13 +177,13 @@ def getProteinsFastaForGenomeId(genomeId):
         idsFixedFasta += line
     return idsFixedFasta
 
-def getPatricGenesPgfamsForGenomeList(genomeIdList):
+def getPatricGenesPgfamsForGenomeSet(genomeIdSet):
     if Debug:
-        LOG.write("getPatricGenesPgfamsForGenomeList() called for %d genomes\n"%len(genomeIdList))
+        LOG.write("getPatricGenesPgfamsForGenomeSet() called for %d genomes\n"%len(genomeIdSet))
         LOG.write("    Session headers=\n"+str(Session.headers)+"\n")
     retval = []
     # one genome at a time, so using 'get' should be fine
-    for genomeId in genomeIdList:
+    for genomeId in genomeIdSet:
         query="and(%s,%s,%s)"%("eq(genome_id,(%s))"%genomeId, "eq(feature_type,CDS)", "eq(pgfam_id,PGF*)")
         query += "&select(genome_id,patric_id,pgfam_id)"
         query += "&limit(10000)"

--- a/lib/patric_api.py
+++ b/lib/patric_api.py
@@ -114,9 +114,9 @@ def getGenomeFeaturesByPatricIds(patricIdList, fieldNames=None):
         retval.append(fields)
     return(retval)
 """
-def getProteinFastaForPatricIds(patricIdList):
-    query="in(patric_id,("+",".join(map(urllib.quote, patricIdList))+"))"
-    query += "&limit(%d)"%len(patricIdList)
+def getProteinFastaForPatricIds(patricIds):
+    query="in(patric_id,("+",".join(map(urllib.quote, patricIds))+"))"
+    query += "&limit(%d)"%len(patricIds)
     response=Session.get(Base_url+"genome_feature/", params=query, headers={'Accept': 'application/protein+fasta'})
     if Debug:
         LOG.write("getProteinFastaForByPatricIds:\nurl="+response.url+"\nquery="+query+"\n")
@@ -135,9 +135,9 @@ def getProteinFastaForPatricIds(patricIdList):
         idsFixedFasta += line+"\n"
     return idsFixedFasta
     
-def getDnaFastaForPatricIds(patricIdList):
-    query="in(patric_id,("+",".join(map(urllib.quote, patricIdList))+"))"
-    query += "&limit(%d)"%len(patricIdList)
+def getDnaFastaForPatricIds(patricIds):
+    query="in(patric_id,("+",".join(map(urllib.quote, patricIds))+"))"
+    query += "&limit(%d)"%len(patricIds)
     response=Session.get(Base_url+"genome_feature/", params=query, headers={'Accept': 'application/dna+fasta'})
     if Debug:
         LOG.write("getDnaFastaForByPatricIds:\nurl="+response.url+"\nquery="+query+"\n")

--- a/lib/phylocode.py
+++ b/lib/phylocode.py
@@ -383,6 +383,9 @@ def writeConcatenatedAlignmentsPhylip(alignments, destination):
         writeOneAlignmentPhylip(alignments[alignmentId], destination, taxonIdList, outputIds=False)
 
 def outputCodonsProteinsPhylip(codonAlignments, proteinAlignments, destination):
+    if len(codonAlignments) == 0:
+        LOG.write("outputCodonsProteinsPhylip() called with zero codonAlignments()\n")
+        return
     if type(destination) == str:
         if Debug:
             LOG.write("outputCodonsProteinsPhylip opening file %s\n"%destination)

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -61,15 +61,15 @@ patric_api.LOG = LOG
 subprocess.check_call(['which', args.raxmlExecutable])
 phylocode.checkMuscle()
 
-genomeIds = []
+ingroupIds = set() # keep unique
 if args.genomeIdsFile:
     with open(args.genomeIdsFile) as F:
         for line in F:
             m = re.match(r"(\d+\.\d+)", line)
             if m:
-                genomeIds.append(m.group(1))
+                ingroupIds.add(m.group(1))
 LOG.write("elapsed seconds = %f\n"%(time()-starttime))
-LOG.write("from %s got %d genomeIds\n%s\n"%(args.genomeIdsFile, len(genomeIds), "\t".join(genomeIds)))
+LOG.write("from %s got %d ingroupIds\n%s\n"%(args.genomeIdsFile, len(ingroupIds), "\t".join(ingroupIds)))
 if args.genomeObjectFile:
     LOG.write("genome object file: %s\n"%args.genomeObjectFile)
 LOG.flush()
@@ -78,29 +78,30 @@ if args.genomeGroupName:
     LOG.write("requesting genome IDs for user group %s\n"%args.genomeGroupName)
     ids = patric_api.getGenomeGroupIds(args.genomeGroupName)
     LOG.write("got %d ids for %s\n"%(len(ids), args.genomeGroupName))
-    genomeIds.extend(ids)
+    ingroupIds.update(set(ids))
 
-outgroupIds = []
+outgroupIds = set()
 if args.outgroupIdsFile:
     with open(args.outgroupIdsFile) as F:
         for line in F:
             m = re.match(r"(\d+\.\d+)", line)
             if m:
-                outgroupIds.append(m.group(1))
+                outgroupIds.add(m.group(1))
 LOG.write("got %d outgroupIds\n%s\n"%(len(outgroupIds), "\t".join(outgroupIds)))
 LOG.flush()
 
-if len(genomeIds) + len(outgroupIds) < 4:
-    LOG.write("too few genomeIds to build a tree with: %d"%(len(genomeIds)+len(outgroupIds)))
+if len(ingroupIds) + len(outgroupIds) < 4:
+    LOG.write("too few genomes to build a tree with: %d"%(len(ingroupIds)+len(outgroupIds)))
     sys.exit(1)
 
+# figure out a base name for ouput files
 if args.genomeIdsFile:
     fileBase = os.path.basename(args.genomeIdsFile)
+    fileBase = re.sub("\..*", "", fileBase)
 elif args.genomeGroupName:
     fileBase = args.genomeGroupName
 else:
     fileBase = "codon_tree"
-fileBase = re.sub("\..*", "", fileBase)
 
 # if either codons or proteins is specified, analyze just that, otherwise analyze both
 if (args.analyzeCodons or args.analyzeProteins):
@@ -116,8 +117,8 @@ LOG.flush()
 if args.debugMode:
     patric_api.Debug = True
     phylocode.Debug = True
-    patric_api.LOG = LOG
-    phylocode.LOG = LOG
+patric_api.LOG = LOG
+phylocode.LOG = LOG
 
 
 # this is where we gather the list of Pgfam genes for each ingroup genome ID
@@ -131,7 +132,7 @@ if False and args.genomeGenePgfamsFile: # reserve for future use (convenient for
             if len(row) == 3:
                 genomeGenePgfamList.append(row)
 else:
-    genomeGenePgfamList = patric_api.getPatricGenesPgfamsForGenomeList(genomeIds)
+    genomeGenePgfamList = patric_api.getPatricGenesPgfamsForGenomeSet(ingroupIds)
 
 genomeObject=None
 genomeObject_genomeId=None
@@ -143,7 +144,7 @@ if args.genomeObjectFile:
     genomeGenePgfamList.extend(genomeObjectGenePgfams)
     genomeObject_genomeId = genomeObject['id']
     genomeObject_name = genomeObject['scientific_name']
-    genomeIds.append(genomeObject_genomeId)
+    ingroupIds.add(genomeObject_genomeId)
     args.focusGenome = genomeObject_genomeId
     LOG.write("parsed json file %s, got PGFam genes=%d, total now is %d\n"%(args.genomeObjectFile, len(genomeObjectGenePgfams), len(genomeGenePgfamList)))
     LOG.flush()
@@ -152,7 +153,7 @@ if args.genomeObjectFile:
 
 # add outgroup genes+pgfams to list, get dynamically as the outgroup might change from run to run
 if len(outgroupIds):
-    genomeGenePgfamList.extend(patric_api.getPatricGenesPgfamsForGenomeList(outgroupIds))
+    genomeGenePgfamList.extend(patric_api.getPatricGenesPgfamsForGenomeSet(outgroupIds))
 
 with open(args.outputDirectory+fileBase+".genomeGenePgfams.txt", 'w') as F:
     for row in genomeGenePgfamList:
@@ -166,12 +167,12 @@ if not len(genomeGenePgfamList):
     LOG.write("got no genes and pgfams for genomes, exiting\n")
     sys.exit(1)
 
-LOG.write("allowing %d genomes missing per PGfam of ingroup (out of %d total)\n"%(args.maxGenomesMissing, len(genomeIds)))
-if args.maxGenomesMissing >= len(genomeIds):
+LOG.write("allowing %d genomes missing per PGfam of ingroup (out of %d total)\n"%(args.maxGenomesMissing, len(ingroupIds)))
+if args.maxGenomesMissing >= len(ingroupIds)-4:
     raise Exception("getSingleCopyPgfams: maxGenomesMissing too large: %d"%args.maxGenomesMissing)
 
 # call to getSingleCopyPgfams uses ingroup taxa, outgroup is not involved in selecting single copy pgfams
-singleCopyPgfams = phylocode.selectSingleCopyPgfams(genomeGenePgfamList, genomeIds, requiredGenome=args.focusGenome, maxGenomesMissing=args.maxGenomesMissing, maxAllowedDups=args.maxAllowedDups)
+singleCopyPgfams = phylocode.selectSingleCopyPgfams(genomeGenePgfamList, ingroupIds, requiredGenome=args.focusGenome, maxGenomesMissing=args.maxGenomesMissing, maxAllowedDups=args.maxAllowedDups)
 
 LOG.write("got single copy pgfams, num=%d\n"%len(singleCopyPgfams))
 if len(singleCopyPgfams) > args.maxGenes:
@@ -185,12 +186,12 @@ with open(args.outputDirectory+fileBase+".singlishCopyPgfams.txt", 'w') as F:
     for pgfam in singleCopyPgfams:
         F.write(pgfam+"\n")
 
-allGenomeIds = genomeIds
-allGenomeIds.extend(outgroupIds)
+allGenomeIds = ingroupIds
+allGenomeIds.update(outgroupIds)
 #genesForPgfams = phylocode.getGenesForPgfams(genomeGenePgfamList, allGenomeIds, singleCopyPgfams)
 genesForPgfams={}
 for pgfam in singleCopyPgfams:
-    genesForPgfams[pgfam] = []
+    genesForPgfams[pgfam] = set()
 genomeObjectGeneDna={}
 genomeObjectGenes=set()
 geneToGenomeId = {} # to easily get genome id for a gene 
@@ -199,7 +200,7 @@ for row in genomeGenePgfamList:
     genome, gene, pgfam = row
     if genome in allGenomeIds and pgfam in genesForPgfams:
         geneToGenomeId[gene] = genome
-        genesForPgfams[pgfam].append(gene)
+        genesForPgfams[pgfam].add(gene)
         if genome == genomeObject_genomeId:
             genomeObjectGenes.add(gene)
         numGenesAdded += 1
@@ -395,7 +396,7 @@ if not args.deferRaxml:
             figtreePdfName = args.outputDirectory+phyloFileBase+".figtree.pdf"
             if args.debugMode:
                 LOG.write("run figtree to create tree figure: %s\n"%figtreePdfName)
-            phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)
+            phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(ingroupIds), args.pathToFigtreeJar)
             if True: # possibly gate this by a parameter
                 # Now write a version of tree with tip labels aligned (shows bootstap support better)
                 figtreeParams['rectilinearLayout.alignTipLabels'] = 'true'
@@ -403,7 +404,7 @@ if not args.deferRaxml:
                 phylocode.writeTranslatedNexusTree(nexusOut, originalNewick, genomeIdToName, figtreeParameters=figtreeParams, highlightGenome=args.focusGenome)
                 nexusOut.close()
                 figtreePdfName = args.outputDirectory+phyloFileBase+"_figtree_tipLabelsAligned.pdf"
-                phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)
+                phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(ingroupIds), args.pathToFigtreeJar)
 LOG.write(strftime("%a, %d %b %Y %H:%M:%S", localtime(time()))+"\n")
 LOG.write("Total job duration %d seconds\n"%(time()-starttime))
         

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -36,9 +36,19 @@ parser.add_argument("--debugMode", action='store_true', help="turns on more prog
 #parser.add_argument("--enableGenomeGenePgfamFileReuse", action='store_true', help="read genes and pgfams from stored file matching genomeIdsFile if it exists")
 args = parser.parse_args()
 starttime = time()
+
+if not args.outputDirectory:
+    args.outputDirectory=fileBase+"_dir/"
+if not args.outputDirectory.endswith("/"):
+    args.outputDirectory += "/"
+if not os.path.exists(args.outputDirectory):
+    os.makedirs(args.outputDirectory)
+
 logfileName = os.path.basename(sys.argv[0])
 logfileName = re.sub("\..*", "", logfileName)
 logfileName += ".log"
+logfileName = os.path.join(args.outputDirectory, logfileName)
+
 global LOG 
 LOG = open(logfileName, 'w')
 LOG.write("starting %s\n"%sys.argv[0])
@@ -102,15 +112,6 @@ else:
     args.analyzeCodons = args.analyzeProteins = True
     LOG.write("analyzing both codons and proteins\n")
 LOG.flush()
-
-if not args.outputDirectory:
-    args.outputDirectory=fileBase+"_dir/"
-if not args.outputDirectory.endswith("/"):
-    args.outputDirectory += "/"
-if os.path.exists(args.outputDirectory):
-    LOG.write("data directory %s exists\n"%args.outputDirectory)
-else:
-    os.mkdir(args.outputDirectory)
 
 if args.debugMode:
     patric_api.Debug = True
@@ -386,7 +387,7 @@ if not args.deferRaxml:
         LOG.write("nexus file written to %s\n"%nexusOutfileName)
         LOG.flush()
         if not (args.pathToFigtreeJar and os.path.exists(args.pathToFigtreeJar)):
-            LOG.write("Could not find valid path to figtree.jar")
+            LOG.write("Could not find valid path to figtree.jar\n")
             args.pathToFigtreeJar = None
         if args.pathToFigtreeJar:
             LOG.write("found figtree.jar at %s\n"%args.pathToFigtreeJar)
@@ -394,7 +395,6 @@ if not args.deferRaxml:
             figtreePdfName = args.outputDirectory+phyloFileBase+".figtree.pdf"
             if args.debugMode:
                 LOG.write("run figtree to create tree figure: %s\n"%figtreePdfName)
-            #def generateFigtreeImage(nexusFile, outfileName, numTaxa, figtreeJarFile, imageFormat="PDF")
             phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)
             if True: # possibly gate this by a parameter
                 # Now write a version of tree with tip labels aligned (shows bootstap support better)

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -381,7 +381,7 @@ if not args.deferRaxml:
         figtreeParams = {}
         LOG.write("Could not find valid template nexus file.\n")
         LOG.flush()
-    nexusOutfileBase = os.path.join(args.outputDirectory, phyloFileBase+"_figtree")
+    nexusOutfileBase = os.path.join(args.outputDirectory, "CodonTree")
     nexusFilesWritten = phylocode.generateNexusFile(originalNewick, nexusOutfileBase, nexus_template = nexus_template_file, align_tips = "both", focus_genome = args.focusGenome, genomeIdToName=genomeIdToName)
     LOG.write("nexus file written to %s\n"%(", ".join(nexusFilesWritten)))
 

--- a/scripts/p3x-convert-newick-to-nexus.py
+++ b/scripts/p3x-convert-newick-to-nexus.py
@@ -2,63 +2,52 @@ import sys
 import re
 import os.path
 import argparse
-import subprocess
-Codon_trees_lib_path = os.path.dirname(sys.argv[0]).replace("scripts", "lib")
-sys.path.append(Codon_trees_lib_path)
 import patric_api
 import phylocode
 
 parser = argparse.ArgumentParser()
 parser.add_argument("newickTreeFile", metavar="tree file", type=str, help="newick tree file labeled with PATRIC genome IDs")
-parser.add_argument("--modelNexusFile", metavar="nexus", type=str, help="genome object (json file) to be added to ingroup")
+parser.add_argument("--nexusTemplateFile", metavar="nexus", type=str, help="default values for Figtree visualization")
 parser.add_argument("--focusGenome", metavar="genome_id", type=str, help="genome to be highlighted in color in Figtree")
 parser.add_argument("--pathToFigtreeJar", type=str, metavar="jar_file", help="specify this to generate PDF graphic")
+parser.add_argument("--outputDirectory", type=str, default=".", metavar="DIR", help="where output should go")
+parser.add_argument("--alignTips", choices=['yes', 'no', 'both'], type=str, default='both', help="how to draw tips")
 parser.add_argument("--debugMode", action='store_true', help="more progress output")
 args = parser.parse_args()
 
-figtreeParams={}
-if not args.modelNexusFile:
-    args.modelNexusFile = os.path.join(Codon_trees_lib_path, "figtree.nex")
+logfile = os.path.basename(sys.argv[0])
+logfile = re.sub('.py', '.nex', logfile)
+LOG = open(logfile, 'w')
+phylocode.LOG = LOG
+if not args.nexusTemplateFile:
+    for dirname in sys.path: # should be in .../codon_trees/lib
+        if os.path.isfile(os.path.join(dirname, "figtree.nex")):
+            args.nexusTemplateFile = os.path.join(dirname, "figtree.nex")
 # read a model figtree nexus file
-if os.path.exists(args.modelNexusFile):
-    figtreeParams = phylocode.readFigtreeParameters(args.modelNexusFile)
+figtreeParams={}
+if os.path.exists(args.nexusTemplateFile):
+    LOG.write("Found figtree template file: %s\n"%args.nexusTemplateFile)
+    LOG.flush()
+    figtreeParams = phylocode.readFigtreeParameters(args.nexusTemplateFile)
 
 newick = open(args.newickTreeFile).read()
 genomeIds = re.findall("[(,]([^(,):]+)[,:)]", newick)
-sys.stderr.write("\n".join(genomeIds))
+LOG.write("\n".join(genomeIds))
 
-genomeIdToName = {}
-for genomeId, genomeName in patric_api.getNamesForGenomeIds(genomeIds):
-    genomeIdToName[genomeId] = genomeName+" "+genomeId
+nexusOutfileBase = os.path.basename(args.newickTreeFile)
+nexusOutfileBase = re.sub(".n[ewick]+$", "", nexusOutfileBase)
+nexusOutfileBase = nexusOutfileBase+"_figtree"
+nexusOutfileBase = os.path.join(args.outputDirectory, nexusOutfileBase)
 
-outfileBase = re.sub(".n[ewick]+$", "", args.newickTreeFile)
-nexusOutfileName = outfileBase+"_figtree.nex"
-nexusOut = open(nexusOutfileName, "w")
-phylocode.writeTranslatedNexusTree(nexusOut, newick, genomeIdToName, figtreeParameters=figtreeParams, highlightGenome=args.focusGenome)
-nexusOut.close()
-sys.stderr.write("nexus file written to %s\n"%nexusOutfileName)
+nexusFilesWritten = phylocode.generateNexusFile(newick, nexusOutfileBase, nexus_template = args.nexusTemplateFile, align_tips = args.alignTips, focus_genome = args.focusGenome, genomeIdToName=None)
+LOG.write("nexus file written to %s\n"%(", ".join(nexusFilesWritten)))
 
 numTaxa = len(genomeIds)
-if not args.pathToFigtreeJar:
-    if os.path.exists(os.path.join(Codon_trees_lib_path, "figtree.jar")):
-        args.pathToFigtreeJar = os.path.join(Codon_trees_lib_path, "figtree.jar")
 if args.pathToFigtreeJar:
-    if os.path.exists(args.pathToFigtreeJar):
-        if args.debugMode:
-            sys.stderr.write("found figtree.jar at %s\n"%args.pathToFigtreeJar)
-    else:
-        sys.stderr.write("Could not find figtree.jar")
-        args.pathToFigtreeJar = None
-if args.pathToFigtreeJar:
-        figtreePdfName = outfileBase+"_figtree.pdf"
-        #def generateFigtreeImage(nexusFile, outfileName, numTaxa, figtreeJarFile, imageFormat="PDF")
-        phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)
-        # Now write a version of tree with tip labels aligned (shows bootstap support better)
-        if True: # possibly gate this by a parameter
-            figtreeParams['rectilinearLayout.alignTipLabels'] = 'true'
-            nexusOut = open(nexusOutfileName, "w")
-            phylocode.writeTranslatedNexusTree(nexusOut, newick, genomeIdToName, figtreeParameters=figtreeParams, highlightGenome=args.focusGenome)
-            nexusOut.close()
-            figtreePdfName = outfileBase+"_figtree_tipLabelsAligned.pdf"
-            phylocode.generateFigtreeImage(nexusOutfileName, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)
-            
+    if not os.path.exists(args.pathToFigtreeJar):
+        message = "specified figtree.jar does not exist: %s\n"%args.pathToFigtreeJar
+        LOG.write(message)
+        raise Exception(message)
+    for nexusFile in nexusFilesWritten:
+        figtreePdfName = re.sub(".nex", "_figtree.pdf", nexusFile)
+        phylocode.generateFigtreeImage(nexusFile, figtreePdfName, len(genomeIds), args.pathToFigtreeJar)


### PR DESCRIPTION
Test for redundancy. Give preference to sequences from genome object, because it is presumably the entity that wants to be in the tree, even if an existing genome of that ID exists in database.