### PR TITLE
Add genome_name to fields packed into phyloxml tree.

### DIFF
--- a/lib/patric_api.py
+++ b/lib/patric_api.py
@@ -395,50 +395,62 @@ def getPgfamMatrixFromUniversalRoles(genomeIdSet, universalRolesFile, ggpMat=Non
         ggpMat[pgfam][genome].add(gene)
     return ggpMat
 
-def write_homolog_gene_matrix(ggpMat, fileHandle):
+def write_homolog_gene_matrix(ggpMat, fileHandle, minProp=0):
     """ write out homologGeneMatrix to file handle 
     data is list of genes per homolog per genome
     rows are homologs
     cols are genomes
     column headers identify genomes
     genes are comma-separated
+    write only rows where > minProp*num_genomes genomes have genes
+    if minProp is > 1, write rows where > minProp genomes have genes
     """
     # first collect set of all genomes
     genomeSet = set()
     for homolog in ggpMat:
         genomeSet.update(set(ggpMat[homolog].keys()))
     genomes = sorted(genomeSet)
+    min_genomes_required =  minProp
+    if minProp < 1:
+        min_genomes_required = minProp * len(genomes)
     fileHandle.write("PGFam\t"+"\t".join(genomes)+"\n")
     for homolog in ggpMat:
-        fileHandle.write(homolog)
-        for genome in genomes:
-            gene = ""
-            if genome in ggpMat[homolog]:
-                gene = ",".join(ggpMat[homolog][genome])
-            fileHandle.write("\t"+gene)
-        fileHandle.write("\n")
+        if len(ggpMat[homolog]) >= min_genomes_required:
+            fileHandle.write(homolog)
+            for genome in genomes:
+                gene = ""
+                if genome in ggpMat[homolog]:
+                    gene = ",".join(ggpMat[homolog][genome])
+                fileHandle.write("\t"+gene)
+            fileHandle.write("\n")
 
-def write_homolog_count_matrix(ggpMat, fileHandle):
+def write_homolog_count_matrix(ggpMat, fileHandle, minProp=0):
     """ write out matrix of counts per homolog per genome to file handle 
     data is count of genes per homolog per genome (integers)
     rows are homologs
     cols are genomes
     column headers identify genomes
+    write only rows where > minProp*num_genomes genomes have genes
+    if minProp is > 1, write rows where > minProp genomes have genes
     """
     # first collect set of all genomes
     genomeSet = set()
     for homolog in ggpMat:
         genomeSet.update(set(ggpMat[homolog].keys()))
     genomes = sorted(genomeSet)
+    min_genomes_required =  minProp
+    if minProp < 1:
+        min_genomes_required = minProp * len(genomes)
     fileHandle.write("PGFam\t"+"\t".join(genomes)+"\n")
     for homolog in ggpMat:
-        fileHandle.write(homolog)
-        for genome in genomes:
-            count = 0
-            if genome in ggpMat[homolog]:
-                count = len(ggpMat[homolog][genome])
-            fileHandle.write("\t%d"%count)
-        fileHandle.write("\n")
+        if len(ggpMat[homolog]) >= min_genomes_required:
+            fileHandle.write(homolog)
+            for genome in genomes:
+                count = 0
+                if genome in ggpMat[homolog]:
+                    count = len(ggpMat[homolog][genome])
+                fileHandle.write("\t%d"%count)
+            fileHandle.write("\n")
 
 def read_homolog_gene_matrix(fileHandle):
     """ read homologGeneMatrix from file handle

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -47,7 +47,7 @@ parser.add_argument("--writePgfamAlignments", action='store_true', help="write f
 parser.add_argument("--writePgfamMatrix", type=float, help="write table of gene_id per homolog per genome (present in > proportion of genomes)")
 parser.add_argument("--writePgfamCountMatrix", type=float, help="write table of counts per homolog per genome (present in > proportion of genomes)")
 parser.add_argument("--writePhyloxml", action='store_true', help="write tree in phyloxml format")
-parser.add_argument("--phyloxmlFields", type=str, default='species,strain,geographic_group,isolation_country,host_group,host_common_name,collection_year,subtype,lineage,clade', metavar='data fields', help="comma-sparated genome fields for phyloxml")
+parser.add_argument("--phyloxmlFields", type=str, default='genome_name,species,strain,isolation_country,host_common_name,collection_year', metavar='data fields', help="comma-sparated genome fields for phyloxml")
 parser.add_argument("--pathToFigtreeJar", type=str, metavar="path", help="not needed if figtree executable on path")
 parser.add_argument("--universalRolesFile", type=str, metavar="path", help="path to file with universal roles to select conserved genes")
 parser.add_argument("--focusGenome", metavar="id", type=str, help="to be highlighted in color in Figtree")
@@ -543,6 +543,9 @@ if len(proteinAlignments):
         if return_code != 0:
             LOG.write("raxml run to find best protein model failed.\n")
 
+        filesToMoveToDetailsFolder.append(proteinAlignmentFile)
+        if os.path.exists(proteinAlignmentFile+".reduced"):
+            filesToDelete.append(proteinAlignmentFile+".reduced")
         protein_substitution_model = "LG" # default if we don't find answer
         if os.path.exists("RAxML_info."+proteinFileBase):
             filesToMoveToDetailsFolder.append("RAxML_info."+proteinFileBase)
@@ -590,7 +593,7 @@ if len(proteinAlignments):
         alignmentFile = phyloFileBase+".phy"
         filesToMoveToDetailsFolder.append(alignmentFile)
         phylocode.writeConcatenatedAlignmentsPhylip(proteinAlignments, alignmentFile)
-        raxmlCommand = [args.raxmlExecutable, "-s", phyloFileBase+".phy", "-n", phyloFileBase, "-m",  "PROT%s%s"%(rate_model, protein_substitution_model), "-p", "12345", "-T", str(args.threads)]
+        raxmlCommand = [args.raxmlExecutable, "-s", alignmentFile, "-n", phyloFileBase, "-m",  "PROT%s%s"%(rate_model, protein_substitution_model), "-p", "12345", "-T", str(args.threads)]
     #raxmlCommand.extend(["-e", "0.1"]) #limit on precision, faster than default 0.1
 
     if args.bootstrapReps > 0:
@@ -641,6 +644,8 @@ if len(proteinAlignments) and not args.deferRaxml:
         if os.path.exists("RAxML_bipartitions."+fileBase):
             raxmlNewickFileName = "RAxML_bipartitions."+fileBase
             filesToMoveToDetailsFolder.append("RAxML_info."+fileBase)
+        if os.path.exists(alignmentFile+".reduced"):
+            filesToDelete.append(alignmentFile+".reduced")
         
     program_return_value = 1 # return this to signal no tree was generated == failure
     treeWithGenomeIdsFile = None
@@ -878,7 +883,7 @@ if args.writePhyloxml and treeWithGenomeIdsFile:
     if args.debugMode:
         sys.stderr.write("calling p3x-newick-to-phyloxml, command line:\n"+" ".join(command)+"\n")
     result_code = subprocess.call(command, shell=False) #/, stdout=LOG, stderr=LOG)
-    phyloxml_file = treeWithGenomeIdsFile.replace(".nwk", ".xml")
+    phyloxml_file = treeWithGenomeIdsFile.replace(".nwk", ".phyloxml")
 
 
 LOG.write("output written to directory %s\n"%args.outputDirectory)
@@ -899,8 +904,6 @@ for fn in filesToMoveToDetailsFolder:
         LOG.write("tried to move {} to detailsDirectory, but not found.\n".format(fn))
 LOG.write("files moved: %d\n"%numMoved)
 filesToDelete.extend(glob.glob("RAxML*"))
-if os.path.exists(phyloFileBase+".phy.reduced"):
-    filesToDelete.append(phyloFileBase+".phy.reduced")
 if not args.debugMode:
     numDeleted = 0
     for fn in filesToDelete:

--- a/scripts/p3x-build-codon-tree.py
+++ b/scripts/p3x-build-codon-tree.py
@@ -44,8 +44,8 @@ parser.add_argument("--analyzeProteins", action='store_true', help="analyze only
 parser.add_argument("--threads", "-t", metavar="T", type=int, default=2, help="threads for raxml")
 parser.add_argument("--deferRaxml", action='store_true', help="does not run raxml")
 parser.add_argument("--writePgfamAlignments", action='store_true', help="write fasta alignment per homolog used for tree")
-parser.add_argument("--writePgfamMatrix", action='store_true', help="write table of gene_id per homolog per genome")
-parser.add_argument("--writePgfamCountMatrix", action='store_true', help="write table of counts per homolog per genome")
+parser.add_argument("--writePgfamMatrix", type=float, help="write table of gene_id per homolog per genome (present in > proportion of genomes)")
+parser.add_argument("--writePgfamCountMatrix", type=float, help="write table of counts per homolog per genome (present in > proportion of genomes)")
 parser.add_argument("--writePhyloxml", action='store_true', help="write tree in phyloxml format")
 parser.add_argument("--phyloxmlFields", type=str, default='species,strain,geographic_group,isolation_country,host_group,host_common_name,collection_year,subtype,lineage,clade', metavar='data fields', help="comma-sparated genome fields for phyloxml")
 parser.add_argument("--pathToFigtreeJar", type=str, metavar="path", help="not needed if figtree executable on path")
@@ -244,11 +244,11 @@ if len(genomesWithoutData):
 
 if args.writePgfamMatrix:
     with open(os.path.join(args.outputDirectory, args.outputBase+".homologMatrix.txt"), 'w') as F:
-        patric_api.write_homolog_gene_matrix(homologMatrix, F)
+        patric_api.write_homolog_gene_matrix(homologMatrix, F, args.writePgfamMatrix)
 
 if args.writePgfamCountMatrix:
     with open(os.path.join(args.outputDirectory, args.outputBase+".homologCountMatrix.txt"), 'w') as F:
-        patric_api.write_homolog_count_matrix(homologMatrix, F)
+        patric_api.write_homolog_count_matrix(homologMatrix, F, args.writePgfamCountMatrix)
 
 genesPerGenome = {}
 for genome in genomeIds:


### PR DESCRIPTION
We initially thought that species + strain would be a great default label for genome tree. Frequently both of those are missing. Genome name should always be there and is usually approximately the same as species + strain.